### PR TITLE
PAPP-38067: fix Splunk ITSI input handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.8
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2020-2025 Splunk Inc.
+   Copyright (c) 2020-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Splunk IT Service Intelligence for SOAR
-Copyright (c) 2020-2025 Splunk Inc.
+Copyright (c) 2020-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -951,7 +951,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2020-2025 Splunk Inc.
+# Copyright (c) 2020-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+- Quote ITSI identifiers in request paths and episode event searches.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,5 +1,5 @@
 **Unreleased**
 
-* - Quote ITSI identifiers in request paths and episode event searches.
-* - Escape ITSI widget values embedded in JavaScript strings.
-* - Reject XML responses with document type declarations before parsing.
+* Quote ITSI identifiers in request paths and episode event searches.
+* Escape ITSI widget values embedded in JavaScript strings.
+* Reject XML responses with document type declarations before parsing.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,5 +1,5 @@
 **Unreleased**
 
-- Quote ITSI identifiers in request paths and episode event searches.
-- Escape ITSI widget values embedded in JavaScript strings.
-- Reject XML responses with document type declarations before parsing.
+* - Quote ITSI identifiers in request paths and episode event searches.
+* - Escape ITSI widget values embedded in JavaScript strings.
+* - Reject XML responses with document type declarations before parsing.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 - Quote ITSI identifiers in request paths and episode event searches.
+- Escape ITSI widget values embedded in JavaScript strings.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 - Quote ITSI identifiers in request paths and episode event searches.
 - Escape ITSI widget values embedded in JavaScript strings.
+- Reject XML responses with document type declarations before parsing.

--- a/splunkitsi.json
+++ b/splunkitsi.json
@@ -9,7 +9,7 @@
     "product_name": "Splunk ITSI",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "license": "Copyright (c) 2020-2025 Splunk Inc.",
+    "license": "Copyright (c) 2020-2026 Splunk Inc.",
     "app_version": "2.0.2",
     "utctime_updated": "2025-09-08T22:10:47.716888Z",
     "package_name": "phantom_splunkitsi",

--- a/splunkitsi_connector.py
+++ b/splunkitsi_connector.py
@@ -15,10 +15,8 @@
 #
 #
 import json
-from urllib.parse import quote
-
-# Need some time
 import time
+from urllib.parse import quote
 
 import phantom.app as phantom
 import requests
@@ -841,7 +839,11 @@ class SplunkItServiceIntelligenceConnector(BaseConnector):
 
         # make rest call
         ret_val, response = self._make_rest_call(
-            f"/servicesNS/nobody/SA-ITOA/itoa_interface/entity/{self._quote_url_path_component(itsi_entity_id)}", action_result, method="get", params=None, headers=self._headers
+            f"/servicesNS/nobody/SA-ITOA/itoa_interface/entity/{self._quote_url_path_component(itsi_entity_id)}",
+            action_result,
+            method="get",
+            params=None,
+            headers=self._headers,
         )
 
         if phantom.is_fail(ret_val):

--- a/splunkitsi_connector.py
+++ b/splunkitsi_connector.py
@@ -15,6 +15,7 @@
 #
 #
 import json
+from urllib.parse import quote
 
 # Need some time
 import time
@@ -49,6 +50,14 @@ class SplunkItServiceIntelligenceConnector(BaseConnector):
         self._password = None
         self._port = None
         self._token = None
+
+    @staticmethod
+    def _quote_url_path_component(value):
+        return quote(str(value), safe="")
+
+    @staticmethod
+    def _escape_spl_string_literal(value):
+        return str(value).replace("\\", "\\\\").replace('"', '\\"')
 
     def _validate_integer(self, action_result, parameter, key, allow_zero=False):
         if parameter is not None:
@@ -314,7 +323,7 @@ class SplunkItServiceIntelligenceConnector(BaseConnector):
 
         # make rest call
         ret_val, response = self._make_rest_call(
-            f"/servicesNS/nobody/SA-ITOA/event_management_interface/notable_event_group/{itsi_group_id}",
+            f"/servicesNS/nobody/SA-ITOA/event_management_interface/notable_event_group/{self._quote_url_path_component(itsi_group_id)}",
             action_result,
             method="get",
             params=None,
@@ -400,7 +409,7 @@ class SplunkItServiceIntelligenceConnector(BaseConnector):
 
         # make rest call
         ret_val, response = self._make_rest_call(
-            f"/servicesNS/nobody/SA-ITOA/event_management_interface/notable_event_group/{itsi_group_id}",
+            f"/servicesNS/nobody/SA-ITOA/event_management_interface/notable_event_group/{self._quote_url_path_component(itsi_group_id)}",
             action_result,
             method="put",
             params=q_params,
@@ -605,7 +614,7 @@ class SplunkItServiceIntelligenceConnector(BaseConnector):
         earliest_time = "-" + RELATIVE_TIME_VALUES.get(earliest_time, earliest_time)
         search_string = (
             "search index=itsi_grouped_alerts sourcetype=itsi_notable:group NOT source=itsi@internal@group_closing_event "
-            'itsi_group_id="' + itsi_group_id + '"'
+            'itsi_group_id="' + self._escape_spl_string_literal(itsi_group_id) + '"'
             ' | eval itsi_service_ids = split(itsi_service_ids,",") | '
             "mvexpand itsi_service_ids | dedup event_id | head " + str(max_results)
         )
@@ -720,7 +729,7 @@ class SplunkItServiceIntelligenceConnector(BaseConnector):
 
         # make rest call
         ret_val, response = self._make_rest_call(
-            f"/servicesNS/nobody/SA-ITOA/event_management_interface/ticketing/{itsi_group_id}",
+            f"/servicesNS/nobody/SA-ITOA/event_management_interface/ticketing/{self._quote_url_path_component(itsi_group_id)}",
             action_result,
             method="get",
             params=None,
@@ -806,7 +815,7 @@ class SplunkItServiceIntelligenceConnector(BaseConnector):
 
         # make rest call
         ret_val, response = self._make_rest_call(
-            f"/servicesNS/nobody/SA-ITOA/itoa_interface/service/{itsi_service_id}",
+            f"/servicesNS/nobody/SA-ITOA/itoa_interface/service/{self._quote_url_path_component(itsi_service_id)}",
             action_result,
             method="get",
             params=None,
@@ -829,7 +838,7 @@ class SplunkItServiceIntelligenceConnector(BaseConnector):
 
         # make rest call
         ret_val, response = self._make_rest_call(
-            f"/servicesNS/nobody/SA-ITOA/itoa_interface/entity/{itsi_entity_id}", action_result, method="get", params=None, headers=self._headers
+            f"/servicesNS/nobody/SA-ITOA/itoa_interface/entity/{self._quote_url_path_component(itsi_entity_id)}", action_result, method="get", params=None, headers=self._headers
         )
 
         if phantom.is_fail(ret_val):
@@ -902,7 +911,7 @@ class SplunkItServiceIntelligenceConnector(BaseConnector):
 
         # make rest call
         ret_val, response = self._make_rest_call(
-            f"/servicesNS/nobody/SA-ITOA/itoa_interface/service/{itsi_service_id}",
+            f"/servicesNS/nobody/SA-ITOA/itoa_interface/service/{self._quote_url_path_component(itsi_service_id)}",
             action_result,
             method="put",
             params=params,
@@ -969,7 +978,7 @@ class SplunkItServiceIntelligenceConnector(BaseConnector):
 
         # make rest call
         ret_val, response = self._make_rest_call(
-            f"/servicesNS/nobody/SA-ITOA/maintenance_services_interface/maintenance_calendar/{maintenance_window_id}",
+            f"/servicesNS/nobody/SA-ITOA/maintenance_services_interface/maintenance_calendar/{self._quote_url_path_component(maintenance_window_id)}",
             action_result,
             method="get",
             params=None,
@@ -1243,7 +1252,7 @@ class SplunkItServiceIntelligenceConnector(BaseConnector):
 
         # make rest call
         ret_val, response = self._make_rest_call(
-            f"/servicesNS/nobody/SA-ITOA/maintenance_services_interface/maintenance_calendar/{maintenance_window_id}",
+            f"/servicesNS/nobody/SA-ITOA/maintenance_services_interface/maintenance_calendar/{self._quote_url_path_component(maintenance_window_id)}",
             action_result,
             method="put",
             params=params,
@@ -1289,7 +1298,7 @@ class SplunkItServiceIntelligenceConnector(BaseConnector):
 
         # make rest call
         ret_val, response = self._make_rest_call(
-            f"/servicesNS/nobody/SA-ITOA/maintenance_services_interface/maintenance_calendar/{maintenance_window_id}",
+            f"/servicesNS/nobody/SA-ITOA/maintenance_services_interface/maintenance_calendar/{self._quote_url_path_component(maintenance_window_id)}",
             action_result,
             method="post",
             params=params,

--- a/splunkitsi_connector.py
+++ b/splunkitsi_connector.py
@@ -1,6 +1,6 @@
 # File: splunkitsi_connector.py
 #
-# Copyright (c) 2020-2025 Splunk Inc.
+# Copyright (c) 2020-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -285,7 +285,7 @@ class SplunkItServiceIntelligenceConnector(BaseConnector):
 
         self.save_progress("Connecting to endpoint")
         # make rest call
-        ret_val, response = self._make_rest_call(
+        ret_val, _response = self._make_rest_call(
             "/servicesNS/nobody/SA-ITOA/itoa_interface/get_supported_object_types/", action_result, params=None, headers=self._headers
         )
 

--- a/splunkitsi_connector.py
+++ b/splunkitsi_connector.py
@@ -184,8 +184,11 @@ class SplunkItServiceIntelligenceConnector(BaseConnector):
     def _process_xml_response(self, r, action_result):
         resp_json = None
         try:
-            if r.text:
-                resp_json = xmltodict.parse(r.text)
+            xml_content = r.content
+            if b"<!DOCTYPE" in xml_content.upper():
+                return RetVal(action_result.set_status(phantom.APP_ERROR, "XML response contains a DTD, refusing to parse"))
+            if xml_content:
+                resp_json = xmltodict.parse(xml_content)
         except Exception as e:
             error_message = self._get_error_message_from_exception(e)
             return RetVal(action_result.set_status(phantom.APP_ERROR, f"Unable to parse XML response. Error: {error_message}"))

--- a/splunkitsi_consts.py
+++ b/splunkitsi_consts.py
@@ -1,6 +1,6 @@
 # File: splunkitsi_consts.py
 #
-# Copyright (c) 2020-2025 Splunk Inc.
+# Copyright (c) 2020-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunkitsi_get_episode_tickets.html
+++ b/splunkitsi_get_episode_tickets.html
@@ -126,7 +126,7 @@ and limitations under the License.
                       {% if result.param.itsi_group_id %}
                         <a class="no-word-wrap"
                            href="javascript:;"
-                           onclick="context_menu(this, [{'contains': ['splunk itsi group id'], 'value':'{{ result.param.itsi_group_id }}' }], 0, {{ container.id }}, null, false);">
+                                onclick="context_menu(this, [{'contains': ['splunk itsi group id'], 'value':'{{ result.param.itsi_group_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ result.param.itsi_group_id }}
                           &nbsp;
                           <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/splunkitsi_get_episode_tickets.html
+++ b/splunkitsi_get_episode_tickets.html
@@ -12,7 +12,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: splunkitsi_get_episode_tickets.html
-  Copyright (c) 2020-2025 Splunk Inc.
+  Copyright (c) 2020-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -126,7 +126,7 @@ and limitations under the License.
                       {% if result.param.itsi_group_id %}
                         <a class="no-word-wrap"
                            href="javascript:;"
-                                onclick="context_menu(this, [{'contains': ['splunk itsi group id'], 'value':'{{ result.param.itsi_group_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': ['splunk itsi group id'], 'value':'{{ result.param.itsi_group_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ result.param.itsi_group_id }}
                           &nbsp;
                           <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/splunkitsi_get_service.html
+++ b/splunkitsi_get_service.html
@@ -126,7 +126,7 @@ and limitations under the License.
                     {% if data.key %}
                       <a class="no-word-wrap"
                          href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['splunk itsi service id'], 'value':'{{ data.key }}' }], 0, {{ container.id }}, null, false);">
+                            onclick="context_menu(this, [{'contains': ['splunk itsi service id'], 'value':'{{ data.key|escapejs }}' }], 0, {{ container.id }}, null, false);">
                         {{ data.key }}
                         &nbsp;
                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/splunkitsi_get_service.html
+++ b/splunkitsi_get_service.html
@@ -12,7 +12,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: splunkitsi_get_service.html
-  Copyright (c) 2020-2025 Splunk Inc.
+  Copyright (c) 2020-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -126,7 +126,7 @@ and limitations under the License.
                     {% if data.key %}
                       <a class="no-word-wrap"
                          href="javascript:;"
-                            onclick="context_menu(this, [{'contains': ['splunk itsi service id'], 'value':'{{ data.key|escapejs }}' }], 0, {{ container.id }}, null, false);">
+                         onclick="context_menu(this, [{'contains': ['splunk itsi service id'], 'value':'{{ data.key|escapejs }}' }], 0, {{ container.id }}, null, false);">
                         {{ data.key }}
                         &nbsp;
                         <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/splunkitsi_view.py
+++ b/splunkitsi_view.py
@@ -1,6 +1,6 @@
 # File: splunkitsi_view.py
 #
-# Copyright (c) 2020-2025 Splunk Inc.
+# Copyright (c) 2020-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- Encode caller-controlled Splunk ITSI identifiers as individual REST path components and preserve structural query encoding for episode events.
- Escape ITSI values embedded in widget JavaScript string literals.
- Reject XML document type declarations before XML parsing.
- Refresh current pre-commit hooks and their deterministic formatting output.

## Tracking

- PAPP: PAPP-38067 (ESPM-5228)
- PSAAS: PSAAS-30540, PSAAS-30858, PSAAS-31996
- Provenance: VULN-93265 / FS-963; VULN-93583 / FS-1671; VULN-94720 / FS-3242

## Validation

- [x] Full `pre-commit run --all-files --show-diff-on-failure` using isolated Python 3.13, public PyPI, and Docker.
- [x] `git diff --check`
- [x] Documentation: `release_notes/unreleased.md` updated for each functional change.

Written by Codex.