### PR TITLE
PAPP-38298: remediate Splunk ITSI July intake

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.2.4
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Reject unrecognized service-status values instead of enabling the service.
+* Report failed or incomplete ITSI episode-event searches as action errors.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Reject unrecognized service-status values instead of enabling the service.

--- a/splunkitsi_connector.py
+++ b/splunkitsi_connector.py
@@ -907,9 +907,15 @@ class SplunkItServiceIntelligenceConnector(BaseConnector):
         if phantom.is_fail(ret_val):
             return action_result.get_status()
 
+        enabled = OBJECT_STATUS_VALUES.get(service_status)
+        if enabled is None:
+            return action_result.set_status(
+                phantom.APP_ERROR,
+                "Invalid service status. Must be one of: {}.".format(", ".join(OBJECT_STATUS_VALUES)),
+            )
+
         # Create payload for POST request
-        payload = dict()
-        payload["enabled"] = OBJECT_STATUS_VALUES.get(service_status, 1)
+        payload = {"enabled": enabled}
 
         # Create params for POST request
         params = {"is_partial_data": "1"}

--- a/splunkitsi_connector.py
+++ b/splunkitsi_connector.py
@@ -637,6 +637,21 @@ class SplunkItServiceIntelligenceConnector(BaseConnector):
             return action_result.get_status()
 
         for event in response:
+            for message in event.get("messages", []):
+                message_type = str(message.get("type", "")).upper()
+                message_text = str(message.get("text", "")).strip()
+                if message_type in {"ERROR", "FATAL"}:
+                    return action_result.set_status(
+                        phantom.APP_ERROR,
+                        f"Splunk ITSI search failed: {message_text or 'upstream search error'}",
+                    )
+                if message_type == "WARN" and any(marker in message_text.lower() for marker in ("cancel", "incomplete", "truncat")):
+                    return action_result.set_status(
+                        phantom.APP_ERROR,
+                        f"Splunk ITSI search returned incomplete results: {message_text}",
+                    )
+
+        for event in response:
             if event.get("result"):
                 action_result.add_data(event["result"])
 


### PR DESCRIPTION
## Summary

- Enforce the existing `Enabled`/`Disabled` service-status enum before issuing an ITSI update.
- Propagate explicit upstream episode-event search failures and cancellation/incompleteness diagnostics as action errors.
- PSAAS-32925 is excluded: merged PR #25 already percent-encodes every affected ITSI identifier path segment.

## Tracking

- Epic: ESPM-5228
- PAPP: PAPP-38298
- PSAAS: PSAAS-32563, PSAAS-33116

## Validation

- Python 3.13 full pre-commit gate, including Ruff, Semgrep, packaging, static tests, docs, and app linting (public-PyPI isolated provisioning after the internal cache served an empty Ruff wheel).

Written by Codex.